### PR TITLE
Improve the uppercase conversion of fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Django Base Settings
 
-[![Latest Release](https://img.shields.io/github/v/release/vsakkas/django-base-settings.svg?color=187f58)](https://github.com/vsakkas/django-base-settings/releases/tag/v0.2.0)
+[![Latest Release](https://img.shields.io/github/v/release/vsakkas/django-base-settings.svg?color=187f58)](https://github.com/vsakkas/django-base-settings/releases/tag/v0.3.0)
 [![Python](https://img.shields.io/badge/python-3.10+-187f58.svg)](https://www.python.org/downloads/)
 [![Django Version](https://img.shields.io/badge/django-5.0+-187f58)](https://www.djangoproject.com/)
 [![MIT License](https://img.shields.io/badge/license-MIT-187f58)](https://github.com/vsakkas/django-base-settings/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -47,14 +47,11 @@ DEFAULT_FROM_EMAIL = "webmaster@example.com"
 For more complex configurations, you can define nested settings using Pydantic models:
 
 ```python
-from pydantic import Field
-from pydantic_settings import BaseSettings
-
-from django_base_settings import DjangoBaseSettings
+from django_base_settings import BaseSettings, DjangoBaseSettings
 
 class CacheSettings(BaseSettings):
-    backend: str = Field("django.core.cache.backends.redis.RedisCache", alias="BACKEND")
-    location: str = Field("redis://127.0.0.1:6379/1", alias="LOCATION")
+    backend: str = "django.core.cache.backends.redis.RedisCache"
+    location: str = "redis://127.0.0.1:6379/1"
 
 class MySiteSettings(DjangoBaseSettings):
     caches: dict[str, CacheSettings] = {"default": CacheSettings()}

--- a/django_base_settings/__init__.py
+++ b/django_base_settings/__init__.py
@@ -1,1 +1,5 @@
-from .django_base_settings import DjangoBaseSettings  # noqa: F401
+from .django_base_settings import (  # noqa: F401
+    BaseModel,
+    BaseSettings,
+    DjangoBaseSettings,
+)

--- a/django_base_settings/django_base_settings.py
+++ b/django_base_settings/django_base_settings.py
@@ -1,7 +1,16 @@
 import sys
 
-from pydantic import BaseModel
-from pydantic_settings import BaseSettings
+from pydantic import BaseModel as _BaseModel
+from pydantic import ConfigDict
+from pydantic_settings import BaseSettings as _BaseSettings
+
+
+class BaseModel(_BaseModel):
+    model_config = ConfigDict(alias_generator=lambda field_name: field_name.upper())
+
+
+class BaseSettings(_BaseSettings):
+    model_config = ConfigDict(alias_generator=lambda field_name: field_name.upper())
 
 
 class DjangoBaseSettings(BaseSettings):
@@ -47,9 +56,9 @@ class DjangoBaseSettings(BaseSettings):
             if isinstance(field_value, (BaseSettings, BaseModel)):
                 setattr(
                     module,
-                    field_name.upper(),
+                    field_name,
                     field_value.model_dump(by_alias=True),
                 )
             else:
                 # For regular fields, inject the value directly
-                setattr(module, field_name.upper(), field_value)
+                setattr(module, field_name, field_value)

--- a/django_base_settings/django_base_settings.py
+++ b/django_base_settings/django_base_settings.py
@@ -3,6 +3,7 @@ import sys
 from pydantic import BaseModel as _BaseModel
 from pydantic import ConfigDict
 from pydantic_settings import BaseSettings as _BaseSettings
+from pydantic_settings import SettingsConfigDict
 
 
 class BaseModel(_BaseModel):
@@ -10,7 +11,9 @@ class BaseModel(_BaseModel):
 
 
 class BaseSettings(_BaseSettings):
-    model_config = ConfigDict(alias_generator=lambda field_name: field_name.upper())
+    model_config = SettingsConfigDict(
+        alias_generator=lambda field_name: field_name.upper()
+    )
 
 
 class DjangoBaseSettings(BaseSettings):
@@ -53,7 +56,9 @@ class DjangoBaseSettings(BaseSettings):
     def _inject_settings(self, module, settings: BaseSettings) -> None:
         for field_name, field_value in settings.model_dump(by_alias=True).items():
             # For nested models, inject a dictionary representation
-            if isinstance(field_value, (BaseSettings, BaseModel)):
+            if isinstance(
+                field_value, (BaseSettings, BaseModel, _BaseSettings, _BaseModel)
+            ):
                 setattr(
                     module,
                     field_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-base-settings"
-version = "0.2.0"
+version = "0.3.0"
 description = "Use Pydantic to enhance your Django application settings."
 authors = ["vsakkas <vasileios.sakkas96@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
- Improve the uppercase conversion of fields by subclassing `BaseSettings` and `BaseModel` and adding a default `model_config`